### PR TITLE
Bug/receiver window minimized state

### DIFF
--- a/src/components/App/Window.tsx
+++ b/src/components/App/Window.tsx
@@ -49,6 +49,6 @@ const Container = styled.div<{ isOpen: boolean }>`
 
 const Fixed = styled.div`
   position: fixed;
-  bottom: 0.75rem;
+  bottom: 0;
   right: 88px;
 `;


### PR DESCRIPTION
**Note: Pull requests which don't include the minimum details specified
in this template will probably be closed out-of-hand.**

https://github.com/relaycc/receiver/issues/49

This problem came from a fixed positioning of 0.75rem on the window whether it's open or closed. When the window is closed, this allows the Icon to unintentionally hover above the bottom of the screen. When the window is open, it allows the entire window to float 0.75rem above the bottom of the screen, which I'm assuming it's the intended effect. So I adjusted the positioning to zero when the window is closed and 0.75rem when it's open and this will fix the problem. If we don't want the chat window hovering above the bottom of the users screen by 0.75rem, I can switch it to zero as well. 

In order to review this, go in to an individual conversation with someone and minimize it. The Icon will no longer stick out from the bottom of the page when the chat window is minimized which was the problem described in the link above. 
